### PR TITLE
New Admin Abilities, Player Profile Changes, UI changes

### DIFF
--- a/CookingQuest/CookingQuest.API/Controllers/EquipmentController.cs
+++ b/CookingQuest/CookingQuest.API/Controllers/EquipmentController.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CookingQuest.Library.IRepository;
+using CookingQuest.Library.Models.Library;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NLog;
+
+namespace CookingQuest.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class EquipmentController : ControllerBase
+    {
+        private static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
+
+        public IEquipmentRepo equipmentRepo { get; set; }
+        public EquipmentController(IEquipmentRepo equipmentRepo)
+        {
+            this.equipmentRepo = equipmentRepo ?? throw new ArgumentNullException(nameof(equipmentRepo));
+        }
+
+        // GET: api/Equipment
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<EquipmentModel>>> GetEquip()
+        {
+            var equipment = await equipmentRepo.GetAllEquipment();
+
+            if (equipment == null)
+            {
+                return NotFound();
+            }
+
+            _logger.Info($"Returning {equipment.Count()} equipment");
+
+            return Ok(equipment);
+        }
+
+        // GET: api/Equipment/5
+        [HttpGet("{id}", Name = "GetEquip")]
+        public async Task<ActionResult<EquipmentModel>> GetEquip(int id)
+        {
+            if (await equipmentRepo.GetEquipmentById(id) is EquipmentModel equipmentModel)
+            {
+                _logger.Info($"Returning {equipmentModel.Name}");
+                return equipmentModel;
+            }
+
+            return NotFound();
+        }
+
+        // POST: api/Equipment
+        [HttpPost]
+        public async Task<IActionResult> PostEquip([FromBody] EquipmentModel equipmentModel)
+        {
+            int id;
+            try
+            {
+                id = await equipmentRepo.AddEquipment(equipmentModel);
+                _logger.Info($"Adding new Equipment at {id}");
+                return CreatedAtRoute("GetEquip", new { Id = id }, GetEquip(id)); // 201 Created
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+
+        }
+
+        // PUT: api/Equipment/5
+        [HttpPut("{id}")]
+        public async Task<ActionResult> PutEquip(int id, [FromBody] EquipmentModel equipmentModel)
+        {
+            if (id == equipmentModel.EquipmentId && !(await equipmentRepo.GetEquipmentById(id) is null))
+            {
+                if (await equipmentRepo.EditEquipment(equipmentModel))
+                {
+                    _logger.Info($"Edited Equipment {id}");
+                    return NoContent();
+                }
+                else
+                {
+                    return BadRequest();
+                }
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
+        // DELETE: api/Equipment/5
+        [HttpDelete("{id}")]
+        public async Task<ActionResult> DeleteEquip(int id)
+        {
+            if (await equipmentRepo.DeleteEquipment(id))
+            {
+                _logger.Info($"Deleted Equipment {id}");
+                return NoContent();
+            }
+            return NotFound();
+        }
+    }
+}

--- a/CookingQuest/CookingQuest.API/Controllers/LootController.cs
+++ b/CookingQuest/CookingQuest.API/Controllers/LootController.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CookingQuest.Library.IRepository;
+using CookingQuest.Library.Models.Library;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NLog;
+
+namespace CookingQuest.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class LootController : ControllerBase
+    {
+        private static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
+
+        public ILootRepo lootRepo { get; set; }
+        public LootController(ILootRepo lootRepo)
+        {
+            this.lootRepo = lootRepo ?? throw new ArgumentNullException(nameof(lootRepo));
+        }
+
+        // GET: api/Loot
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<LootModel>>> GetLoots()
+        {
+            var loot = await lootRepo.GetAllLoot();
+
+            if (loot == null)
+            {
+                return NotFound();
+            }
+
+            _logger.Info($"Returning {loot.Count()} Loot");
+
+            return Ok(loot);
+        }
+
+        // GET: api/Loot/5
+        [HttpGet("{id}", Name = "GetLoots")]
+        public async Task<ActionResult<LootModel>> GetLoots(int id)
+        {
+            if (await lootRepo.GetLootById(id) is LootModel lootModel)
+            {
+                _logger.Info($"Returning {lootModel.Name}");
+                return lootModel;
+            }
+
+            return NotFound();
+        }
+
+        // POST: api/Loot
+        [HttpPost]
+        public async Task<IActionResult> PostLoots([FromBody] LootModel lootModel)
+        {
+            int id;
+            try
+            {
+                id = await lootRepo.AddLoot(lootModel);
+                _logger.Info($"Adding new Loot at {id}");
+                return CreatedAtRoute("GetLoots", new { Id = id }, GetLoots(id)); // 201 Created
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+
+        }
+
+        // PUT: api/Loot/5
+        [HttpPut("{id}")]
+        public async Task<ActionResult> PutLoots(int id, [FromBody] LootModel lootModel)
+        {
+            if (id == lootModel.LootId && !(await lootRepo.GetLootById(id) is null))
+            {
+                if (await lootRepo.EditLoot(lootModel))
+                {
+                    _logger.Info($"Edited Loot {id}");
+                    return NoContent();
+                }
+                else
+                {
+                    return BadRequest();
+                }
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
+        // DELETE: api/Loot/5
+        [HttpDelete("{id}")]
+        public async Task<ActionResult> DeleteLoots(int id)
+        {
+            if (await lootRepo.DeleteLoot(id))
+            {
+                _logger.Info($"Deleted Loot {id}");
+                return NoContent();
+            }
+            return NotFound();
+        }
+    }
+}

--- a/CookingQuest/CookingQuest.API/Controllers/PlayerController.cs
+++ b/CookingQuest/CookingQuest.API/Controllers/PlayerController.cs
@@ -79,7 +79,30 @@ namespace CookingQuest.API.Controllers
             _logger.Info($"Returning {playerEquip.Count()} equipment from player {id}");
             return Ok(playerEquip);
         }
+        // GET: api/Player/Equipment/{PlayerId}
+        [HttpPost("[action]/{id}")]
+        public async Task<ActionResult> Equipment(int id, EquipmentModel equipmentModel)
+        {
+            var equipment = await PlayerRepo.EditPlayerEquipment(equipmentModel);
 
+            if (equipment == false)
+            {
+                return NotFound();
+            }
+            _logger.Info($"Updated {equipmentModel.Name} for player {id}");
+            return NoContent();
+        }
+        // DELETE: api/Player/loot/Delete/{playerid}
+        [HttpDelete("[action]/{id}")]
+        public async Task<ActionResult> DeleteEquipment(int id)
+        {
+            if (await PlayerRepo.DeletePlayerEquipment(id))
+            {
+                _logger.Info($"Deleted Player Equipment of player: {id}");
+                return NoContent();
+            }
+            return NotFound();
+        }
         // GET: api/Player/Locations/{PlayerId}
         [HttpGet("[action]/{id}")]
         public async Task<ActionResult<IEnumerable<LocationModel>>> Locations(int id)
@@ -107,17 +130,29 @@ namespace CookingQuest.API.Controllers
             _logger.Info($"Returning {loot.Count()} for player {id}");
             return Ok(loot);
         }
-        // POST: api/Player
-        [HttpPost]
-        public async Task<ActionResult> Post([FromBody] string value)
+        // GET: api/Player/Loot/{PlayerId}
+        [HttpPost("[action]/{id}")]
+        public async Task<ActionResult> Loot(int id, LootModel lootModel)
         {
-            int PlayerId = await PlayerRepo.AddPlayer(value);
-            if(PlayerId <= -1)
+            var loot = await PlayerRepo.EditPlayerLoot(lootModel);
+
+            if (loot == false)
             {
-                return BadRequest();
+                return NotFound();
             }
-            _logger.Info($"Route created for {value} ({PlayerId})");
-            return CreatedAtRoute("Get", new { Id = PlayerId }, Get(PlayerId)); ;
+            _logger.Info($"Updated {lootModel.Name} for player {id}");
+            return NoContent();
+        }
+        // DELETE: api/Player/loot/Delete/{playerid}
+        [HttpDelete("[action]/{id}")]
+        public async Task<ActionResult> DeleteLoot(int id)
+        {
+            if (await PlayerRepo.DeletePlayerLoot(id))
+            {
+                _logger.Info($"Deleted Player Loot of player: {id}");
+                return NoContent();
+            }
+            return NotFound();
         }
 
         // PUT: api/Player/5
@@ -140,18 +175,6 @@ namespace CookingQuest.API.Controllers
             {
                 return NotFound();
             }
-        }
-
-        // DELETE: api/Player/5
-        [HttpDelete("{id}")]
-        public async Task<ActionResult> Delete(int id)
-        {
-            if(await PlayerRepo.DeletePlayer(id))
-            {
-                _logger.Info($"Deleted Player {id}");
-                return NoContent();
-            }
-            return NotFound();
         }
     }
 }

--- a/CookingQuest/CookingQuest.Data/Repository/EquipmentRepo.cs
+++ b/CookingQuest/CookingQuest.Data/Repository/EquipmentRepo.cs
@@ -4,7 +4,10 @@ using CookingQuest.Library.Models.Library;
 using NLog;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
+
 namespace CookingQuest.Data.Repository
 {
     public class EquipmentRepo : IEquipmentRepo
@@ -14,8 +17,104 @@ namespace CookingQuest.Data.Repository
         public EquipmentRepo(CookingQuestContext dbContext) =>
             _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
 
+        public async Task<IEnumerable<EquipmentModel>> GetAllEquipment()
+        {
+            try
+            {
+                return await Task.FromResult(Mapper.Map(_dbContext.Equipment));
+            }
+
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return null;
+            }
+        }
+
+        public async Task<EquipmentModel> GetEquipmentById(int PlayerId)
+        {
+            try
+            {
+                var equipment = await _dbContext.Equipment.FindAsync(PlayerId);
+                return Mapper.Map(equipment);
+            }
+
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return null;
+            }
+        }
+        public async Task<int> AddEquipment(EquipmentModel equipmentModel)
+        {
+            try
+            {
+                if (equipmentModel == null)
+                {
+                    throw new ArgumentException();
+                }
+
+                await _dbContext.Equipment.AddAsync(Mapper.Map(equipmentModel));
+                Save();
+
+                return await Task.FromResult(_dbContext.Equipment.OrderByDescending(x => x.EquipmentId).FirstOrDefault().EquipmentId);
+            }
+
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return -1;
+            }
+        }
+        public async Task<bool> EditEquipment(EquipmentModel equipmentModel)
+        {
+            try
+            {
+                if (equipmentModel == null)
+                {
+                    throw new ArgumentException();
+                }
+
+                Equipment currentEquipment = await _dbContext.Equipment.FindAsync(equipmentModel.EquipmentId);
+                Equipment newEquipment = Mapper.Map(equipmentModel);
+
+                _dbContext.Entry(currentEquipment).CurrentValues.SetValues(newEquipment);
+
+                Save();
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return false;
+            }
+        }
+        public async Task<bool> DeleteEquipment(int equipmentId)
+        {
+            try
+            {
+                Equipment currentEquipment = await _dbContext.Equipment.FindAsync(equipmentId);
 
 
+                if (currentEquipment == null)
+                {
+                    throw new ArgumentException();
+                }
+                else
+                {
+                    _dbContext.Equipment.Remove(currentEquipment);
+                    Save();
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return false;
+            }
+        }
         public void Save()
         {
             _dbContext.SaveChanges();

--- a/CookingQuest/CookingQuest.Data/Repository/LootRepo.cs
+++ b/CookingQuest/CookingQuest.Data/Repository/LootRepo.cs
@@ -4,7 +4,10 @@ using CookingQuest.Library.Models.Library;
 using NLog;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
+
 namespace CookingQuest.Data.Repository
 {
     public class LootRepo : ILootRepo
@@ -14,7 +17,105 @@ namespace CookingQuest.Data.Repository
         public LootRepo(CookingQuestContext dbContext) =>
             _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
 
+        public async Task<IEnumerable<LootModel>> GetAllLoot()
+        {
+            try
+            {
+                return await Task.FromResult(Mapper.Map(_dbContext.Loot));
+            }
 
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return null;
+            }
+        }
+
+        public async Task<LootModel> GetLootById(int lootId)
+        {
+            try
+            {
+                var equipment = await _dbContext.Loot.FindAsync(lootId);
+                return Mapper.Map(equipment);
+            }
+
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return null;
+            }
+        }
+
+        public async Task<int> AddLoot(LootModel lootModel)
+        {
+            try
+            {
+                if (lootModel == null)
+                {
+                    throw new ArgumentException();
+                }
+
+                await _dbContext.Loot.AddAsync(Mapper.Map(lootModel));
+                Save();
+
+                return await Task.FromResult(_dbContext.Loot.OrderByDescending(x => x.LootId).FirstOrDefault().LootId);
+            }
+
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return -1;
+            }
+        }
+        public async Task<bool> EditLoot(LootModel lootModel)
+        {
+            try
+            {
+                if (lootModel == null)
+                {
+                    throw new ArgumentException();
+                }
+
+                Loot currentLoot = await _dbContext.Loot.FindAsync(lootModel.LootId);
+                Loot newLoot = Mapper.Map(lootModel);
+
+                _dbContext.Entry(currentLoot).CurrentValues.SetValues(newLoot);
+
+                Save();
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return false;
+            }
+        }
+        public async Task<bool> DeleteLoot(int lootId)
+        {
+            try
+            {
+                Loot currentLoot = await _dbContext.Loot.FindAsync(lootId);
+
+
+                if (currentLoot == null)
+                {
+                    throw new ArgumentException();
+                }
+                else
+                {
+                    _dbContext.Loot.Remove(currentLoot);
+                    Save();
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return false;
+            }
+        }
 
         public void Save()
         {

--- a/CookingQuest/CookingQuest.Data/Repository/PlayerRepo.cs
+++ b/CookingQuest/CookingQuest.Data/Repository/PlayerRepo.cs
@@ -71,9 +71,9 @@ namespace CookingQuest.Data.Repository
             {
                 var player_equipment = await Task.FromResult(_dbContext.PlayerEquipment.Where(x => x.PlayerId == PlayerId));
 
-                var equipment = await Task.FromResult(_dbContext.Equipment);
+                var equipment = Mapper.Map(await Task.FromResult(_dbContext.Equipment));
 
-                var items = new List<Equipment>();
+                var items = new List<EquipmentModel>();
 
                 foreach (var equip in equipment)
                 {
@@ -81,11 +81,12 @@ namespace CookingQuest.Data.Repository
                     {
                         if (pe.EquipmentId == equip.EquipmentId)
                         {
+                            equip.PlayerEquipmentId = pe.PlayerEquipmentId;
                             items.Add(equip);
                         }
                     }
                 }
-                return Mapper.Map(items);
+                return items;
             }
 
             catch (Exception ex)
@@ -128,6 +129,7 @@ namespace CookingQuest.Data.Repository
                         if (pl.LootId == l.LootId)
                         {
                             l.Quantity = pl.Quantity;
+                            l.PlayerLootId = pl.PlayerLootId;
                             items.Add(l);
                         }
                     }
@@ -140,31 +142,7 @@ namespace CookingQuest.Data.Repository
                 return null;
             }
         }
-        public async Task<int> AddPlayer(string name)
-        {
-            try
-            {
-                if (string.IsNullOrWhiteSpace(name))
-                {
-                    throw new ArgumentException();
-                }
-
-                PlayerModel player = new PlayerModel
-                {
-                    Name = name,
-                };
-                await _dbContext.Player.AddAsync(Mapper.Map(player));
-                Save();
-                 
-                return await Task.FromResult(_dbContext.Player.OrderByDescending(x=>x.PlayerId).FirstOrDefault().PlayerId);
-            }
-
-            catch (Exception ex)
-            {
-                _logger.Error(ex.ToString());
-                return -1;
-            }
-        }
+        
         public async Task<bool> EditPlayer(PlayerModel player)
         {
             try
@@ -189,25 +167,100 @@ namespace CookingQuest.Data.Repository
                 return false;
             }
         }
-
-        public async Task<bool> DeletePlayer(int PlayerId)
+        public async Task<bool> EditPlayerLoot(LootModel lootModel)
         {
             try
             {
-                Player CurrentPlayer = await _dbContext.Player.FindAsync(PlayerId);
-
-                if(await Task.FromResult(_dbContext.Account.FirstOrDefault(x => x.PlayerId == PlayerId)) != null)
+                if (lootModel == null)
                 {
                     throw new ArgumentException();
                 }
 
-                if(CurrentPlayer == null)
+                PlayerLoot CurrentLoot = await _dbContext.PlayerLoot.FindAsync(lootModel.PlayerLootId);
+                PlayerLoot newLoot = new PlayerLoot
+                {
+                    LootId = CurrentLoot.LootId,
+                    PlayerId = CurrentLoot.PlayerId,
+                    PlayerLootId = CurrentLoot.PlayerLootId,
+                    Quantity = lootModel.Quantity,
+                };
+                _dbContext.Entry(CurrentLoot).CurrentValues.SetValues(newLoot);
+
+
+                Loot loot = await _dbContext.Loot.FindAsync(lootModel.LootId);
+                Loot newLoot2 = Mapper.Map(lootModel);
+                _dbContext.Entry(loot).CurrentValues.SetValues(newLoot2);
+
+                Save();
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return false;
+            }
+        }
+        public async Task<bool> EditPlayerEquipment(EquipmentModel equipmentModel)
+        {
+            try
+            {
+                if (equipmentModel == null)
+                {
+                    throw new ArgumentException();
+                }
+
+                Equipment equipment = await _dbContext.Equipment.FindAsync(equipmentModel.EquipmentId);
+                Equipment equipment2 = Mapper.Map(equipmentModel);
+                _dbContext.Entry(equipment).CurrentValues.SetValues(equipment2);
+
+                Save();
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return false;
+            }
+        }
+        public async Task<bool> DeletePlayerEquipment(int playerEquipmentId)
+        {
+            try
+            {
+                PlayerEquipment playerEquipment = await _dbContext.PlayerEquipment.FindAsync(playerEquipmentId);
+
+                if (playerEquipment == null)
                 {
                     throw new ArgumentException();
                 }
                 else
                 {
-                    _dbContext.Player.Remove(CurrentPlayer);
+                    _dbContext.PlayerEquipment.Remove(playerEquipment);
+                    Save();
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex.ToString());
+                return false;
+            }
+        }
+        public async Task<bool> DeletePlayerLoot(int PlayerLootId)
+        {
+            try
+            {
+                PlayerLoot playerLoot = await _dbContext.PlayerLoot.FindAsync(PlayerLootId);
+
+                if (playerLoot == null)
+                {
+                    throw new ArgumentException();
+                }
+                else
+                {
+                    _dbContext.PlayerLoot.Remove(playerLoot);
                     Save();
                 }
 

--- a/CookingQuest/CookingQuest.Library/CookingQuest.Library.csproj
+++ b/CookingQuest/CookingQuest.Library/CookingQuest.Library.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.4" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
 

--- a/CookingQuest/CookingQuest.Library/IRepository/IEquipmentRepo.cs
+++ b/CookingQuest/CookingQuest.Library/IRepository/IEquipmentRepo.cs
@@ -1,11 +1,18 @@
-﻿using System;
+﻿using CookingQuest.Library.Models.Library;
+using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace CookingQuest.Library.IRepository
 {
     public interface IEquipmentRepo : IDisposable
     {
+        Task<IEnumerable<EquipmentModel>> GetAllEquipment();
+        Task<EquipmentModel> GetEquipmentById(int PlayerId);
+        Task<int> AddEquipment(EquipmentModel equipmentModel);
+        Task<bool> EditEquipment(EquipmentModel equipmentModel);
+        Task<bool> DeleteEquipment(int equipmentId);
         void Save();
     }
 }

--- a/CookingQuest/CookingQuest.Library/IRepository/ILootRepo.cs
+++ b/CookingQuest/CookingQuest.Library/IRepository/ILootRepo.cs
@@ -1,11 +1,18 @@
-﻿using System;
+﻿using CookingQuest.Library.Models.Library;
+using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace CookingQuest.Library.IRepository
 {
     public interface ILootRepo : IDisposable
     {
+        Task<IEnumerable<LootModel>> GetAllLoot();
+        Task<LootModel> GetLootById(int PlayerId);
+        Task<int> AddLoot(LootModel equipmentModel);
+        Task<bool> EditLoot(LootModel equipmentModel);
+        Task<bool> DeleteLoot(int equipmentId);
         void Save();
     }
 }

--- a/CookingQuest/CookingQuest.Library/IRepository/IPlayerRepo.cs
+++ b/CookingQuest/CookingQuest.Library/IRepository/IPlayerRepo.cs
@@ -14,9 +14,11 @@ namespace CookingQuest.Library.IRepository
         Task<IEnumerable<EquipmentModel>> GetPlayerEquipment(int PlayerId);
         Task<IEnumerable<LocationModel>> GetUnlockedLocations(int PlayerId);
         Task<IEnumerable<LootModel>> GetLoot(int PlayerId);
-        Task<int> AddPlayer(string name);
         Task<bool> EditPlayer(PlayerModel player);
-        Task<bool> DeletePlayer(int PlayerId);
+        Task<bool> EditPlayerLoot(LootModel lootModel);
+        Task<bool> EditPlayerEquipment(EquipmentModel equipmentModel);
+        Task<bool> DeletePlayerEquipment(int playerEquipmentId);
+        Task<bool> DeletePlayerLoot(int PlayerLootId);
         void Save();
     }
 }

--- a/CookingQuest/CookingQuest.Library/Models/Library/EquipmentModel.cs
+++ b/CookingQuest/CookingQuest.Library/Models/Library/EquipmentModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 
 namespace CookingQuest.Library.Models.Library
@@ -7,10 +8,29 @@ namespace CookingQuest.Library.Models.Library
     public class EquipmentModel
     {
         public int EquipmentId { get; set; }
+
+        [Required]
+        [Range(1, 1000, ErrorMessage = "Please enter correct value (Between 1-1000")]
         public int Modifier { get; set; }
+
+        [Required]
+        [StringLength(30, ErrorMessage = "Do not enter more than 30 characters")]
+        [RegularExpression("^[a-zA-Z -]*$", ErrorMessage = "Only Letters from the Alphabet")]
         public string Name { get; set; }
+
+        [Required]
+        [Range(1, 100000, ErrorMessage = "Please enter correct value (Between 1-1000")]
         public int Price { get; set; }
+
+        [Required]
+        [StringLength(30, ErrorMessage = "Do not enter more than 30 characters")]
+        [RegularExpression("^[a-zA-Z -]*$", ErrorMessage = "Only Letters from the Alphabet")]
         public string Type { get; set; }
+
+        [Required]
+        [Range(1, 9, ErrorMessage = "Please enter correct value (Between 1-1000")]
         public int Difficulty { get; set; }
+
+        public int PlayerEquipmentId { get; set; }
     }
 }

--- a/CookingQuest/CookingQuest.Library/Models/Library/LootModel.cs
+++ b/CookingQuest/CookingQuest.Library/Models/Library/LootModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 
 namespace CookingQuest.Library.Models.Library
@@ -7,11 +8,29 @@ namespace CookingQuest.Library.Models.Library
     public class LootModel
     {
         public int LootId { get; set; }
+
+        [Required]
+        [StringLength(30, ErrorMessage = "Do not enter more than 30 characters")]
+        [RegularExpression("^[a-zA-Z -]*$", ErrorMessage = "Only Letters from the Alphabet")]
         public string Name { get; set; }
-        public int Price { get; set; }
+
+        [Required]
+        [Range(1, 100000, ErrorMessage = "Please enter correct value (Between 1-100000")]
+        public int Price { get; set; } = 1;
+
+        [Required]
+        [StringLength(30, ErrorMessage = "Do not enter more than 30 characters")]
+        [RegularExpression("^[a-zA-Z -]*$", ErrorMessage = "Only Letters from the Alphabet")]
         public string Description { get; set; }
 
-        public int Quantity { get; set; } = 0;
-        public int DropRate { get; set; } = 0;
+        [Required]
+        [Range(1, 1000, ErrorMessage = "Please enter correct value (Between 1-1000")]
+        public int Quantity { get; set; } = 1;
+
+        [Required]
+        [Range(1, 1000, ErrorMessage = "Please enter correct value (Between 1-1000")]
+        public int DropRate { get; set; } = 1;
+
+        public int PlayerLootId { get; set; }
     }
 }

--- a/CookingQuest/CookingQuest.Library/Models/Library/PlayerModel.cs
+++ b/CookingQuest/CookingQuest.Library/Models/Library/PlayerModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 
 namespace CookingQuest.Library.Models.Library
@@ -7,7 +8,12 @@ namespace CookingQuest.Library.Models.Library
     public class PlayerModel
     {
         public int PlayerId { get; set; }
+        [Required]
+        [StringLength(30, ErrorMessage = "Do not enter more than 30 characters")]
+        [RegularExpression("^[a-zA-Z -]*$", ErrorMessage = "Only Letters from the Alphabet")]
         public string Name { get; set; }
+        [Required]
+        [Range(1, 1000000, ErrorMessage = "Please enter correct value (Between 1-1000000")]
         public int Gold { get; set; }
     }
 }

--- a/CookingQuest/CookingQuest.Tests/CookingQuest.Tests.csproj
+++ b/CookingQuest/CookingQuest.Tests/CookingQuest.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/CookingQuest/CookingQuest.Tests/MapperTests.cs
+++ b/CookingQuest/CookingQuest.Tests/MapperTests.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CookingQuest.Data;
+using CookingQuest.Data.Entities;
+using CookingQuest.Data.Repository;
+using CookingQuest.Library.Models.Library;
+using Xunit;
+
+namespace CookingQuest.Tests
+{
+    public class MapperTests
+    {
+        [Fact]
+        public void AccountModel()
+        {
+            var model = new AccountModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+
+        [Fact]
+        public void EquipmentModel()
+        {
+            var model = new EquipmentModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+
+        [Fact]
+        public void FlavorLootModel()
+        {
+            var model = new FlavorLootModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void FlavorModel()
+        {
+            var model = new FlavorModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void LocationLootModel()
+        {
+            var model = new LocationLootModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void LocationModel()
+        {
+            var model = new LocationModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void LootModel()
+        {
+            var model = new LootModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void PlayerEquipmentModel()
+        {
+            var model = new PlayerEquipmentModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void PlayerLocationModel()
+        {
+            var model = new PlayerLocationModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void PlayerLootModel()
+        {
+            var model = new PlayerLootModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void PlayerModel()
+        {
+            var model = new PlayerModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void RecipeLootModel()
+        {
+            var model = new RecipeLootModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void RecipeModel()
+        {
+            var model = new RecipeModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void StoreEquipmentModel()
+        {
+            var model = new StoreEquipmentModel();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void StoreFlavor()
+        {
+            var model = new StoreFlavor();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+        [Fact]
+        public void Store()
+        {
+            var model = new Store();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+
+            Assert.IsAssignableFrom(model.GetType(), model3);
+        }
+
+
+
+    }
+}

--- a/CookingQuest/CookingQuest.Tests/MapperTests.cs
+++ b/CookingQuest/CookingQuest.Tests/MapperTests.cs
@@ -140,18 +140,18 @@ namespace CookingQuest.Tests
             Assert.IsAssignableFrom(model.GetType(), model3);
         }
         [Fact]
-        public void StoreFlavor()
+        public void StoreFlavorModel()
         {
-            var model = new StoreFlavor();
+            var model = new StoreFlavorModel();
             var model2 = Mapper.Map(model);
             var model3 = Mapper.Map(model2);
 
             Assert.IsAssignableFrom(model.GetType(), model3);
         }
         [Fact]
-        public void Store()
+        public void StoreModel()
         {
-            var model = new Store();
+            var model = new StoreModel();
             var model2 = Mapper.Map(model);
             var model3 = Mapper.Map(model2);
 
@@ -159,6 +159,182 @@ namespace CookingQuest.Tests
         }
 
 
+        [Fact]
+        public void Account()
+        {
+            IEnumerable<Account> model = new List<Account>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
 
+            Assert.IsType(model3.GetType(), model5);
+        }
+
+        [Fact]
+        public void FlavorLoot()
+        {
+            IEnumerable<FlavorLoot> model = new List<FlavorLoot>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void Equipment()
+        {
+            IEnumerable<Equipment> model = new List<Equipment>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void Flavor()
+        {
+            IEnumerable<Flavor> model = new List<Flavor>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void LocationLoot()
+        {
+            IEnumerable<LocationLoot> model = new List<LocationLoot>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void Location()
+        {
+            IEnumerable<Location> model = new List<Location>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void Loot()
+        {
+            IEnumerable<Loot> model = new List<Loot>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void PlayerEquipment()
+        {
+            IEnumerable<PlayerEquipment> model = new List<PlayerEquipment>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void PlayerLocation()
+        {
+            IEnumerable<PlayerLocation> model = new List<PlayerLocation>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void PlayerLoot()
+        {
+            IEnumerable<PlayerLoot> model = new List<PlayerLoot>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void Player()
+        {
+            IEnumerable<Player> model = new List<Player>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void RecipeLoot()
+        {
+            IEnumerable<RecipeLoot> model = new List<RecipeLoot>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void Recipe()
+        {
+            IEnumerable<Recipe> model = new List<Recipe>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void StoreEquipment()
+        {
+            IEnumerable<StoreEquipment> model = new List<StoreEquipment>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void StoreFlavor()
+        {
+            IEnumerable<StoreFlavor> model = new List<StoreFlavor>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
+        [Fact]
+        public void Store()
+        {
+            IEnumerable<Store> model = new List<Store>();
+            var model2 = Mapper.Map(model);
+            var model3 = Mapper.Map(model2);
+            var model4 = Mapper.Map(model3);
+            var model5 = Mapper.Map(model4);
+
+            Assert.IsType(model3.GetType(), model5);
+        }
     }
 }

--- a/CookingQuest/CookingQuest.Tests/PlayerTests.cs
+++ b/CookingQuest/CookingQuest.Tests/PlayerTests.cs
@@ -1,0 +1,129 @@
+﻿using CookingQuest.Data.Entities;
+using CookingQuest.Data.Repository;
+using CookingQuest.Library.Models.Library;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CookingQuest.Tests
+{
+    public class PlayerTests
+    {
+               [Fact]
+        public async Task Add_AdventurerPartyAsync_writes_to_database()
+        {
+            // In-memory database only exists while the connection is open
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+
+            try
+            {
+                var options = new DbContextOptionsBuilder<CookingQuestContext>()
+                    .UseSqlite(connection)
+                    .Options;
+
+                // Create the schema in the database
+                using (var context = new CookingQuestContext(options))
+                {
+                    context.Database.EnsureCreated();
+                }
+
+                // Run the test against one instance of the context
+                using (var context = new CookingQuestContext(options))
+                {
+                    //create new Repo
+                    context.Player.Add(new Player
+                    {
+                        Gold = 10,
+                        Name = "Test",
+                        PlayerId = 1,
+                    });
+                    context.SaveChanges();
+                    context.Account.Add(new Account
+                    {
+                        AccountId = 1,
+                        IsAdmin = true,
+                        Password = "Easy",
+                        PlayerId = 1,
+                        Username = "paul",
+                    });
+                    context.SaveChanges();
+                    context.Equipment.Add(new Equipment
+                    {
+                        Difficulty = 8,
+                        EquipmentId = 1,
+                        Modifier = 5,
+                        Name = "TestE",
+                        Price = 45,
+                        Type = "Dungeon",
+                    });
+                    context.SaveChanges();
+                    context.PlayerEquipment.Add(new PlayerEquipment
+                    {
+                        EquipmentId = 1,
+                        PlayerId = 1,
+                        PlayerEquipmentId = 1,
+                    });
+                    context.SaveChanges();
+                    context.Location.Add(new Location
+                    {
+                        Description = "Testl",
+                        Difficulty = 1,
+                        LocationId = 1,
+                        Name = "TestNl",
+                    });
+                    context.SaveChanges();
+                    context.Loot.Add(new Loot
+                    {
+                        Description = "a",
+                        LootId = 1,
+                        Name = "l",
+                        Price = 44,
+                    });
+                    context.SaveChanges();
+                    context.PlayerLoot.Add(new PlayerLoot {
+                        LootId = 1,
+                        PlayerId = 1,
+                        PlayerLootId = 1,
+                    });
+                    context.SaveChanges();
+                    var testRepo = new PlayerRepo(context);
+                    var players = await testRepo.GetAllPlayers();
+                    var player = await testRepo.GetPlayerById(1);
+                    var playerEmail = await testRepo.GetPlayerByEmail("paul");
+                    var playerEqp = await testRepo.GetPlayerEquipment(1);
+                    var locationUnl = await testRepo.GetUnlockedLocations(1);
+                    var loot = await testRepo.GetLoot(1);
+                    var editP = await testRepo.EditPlayer(player);
+                    var editPLoot = await testRepo.EditPlayerLoot(loot.ElementAt(0));
+                    var editPEqp = await testRepo.EditPlayerEquipment(playerEqp.ElementAt(0));
+                    var deletePQqp = await testRepo.DeletePlayerEquipment(playerEqp.ElementAt(0).PlayerEquipmentId);
+                    var deletPLoot = await testRepo.DeletePlayerLoot(loot.ElementAt(0).PlayerLootId);
+
+                    Assert.NotEmpty(players);
+                    Assert.NotNull(player);
+                    Assert.Equal("Test", player.Name);
+                    Assert.NotNull(playerEmail);
+                    Assert.NotEmpty(playerEqp);
+                    Assert.NotEmpty(locationUnl);
+                    Assert.NotEmpty(loot);
+                    Assert.True(editP);
+                    Assert.True(editPLoot);
+                    Assert.True(editPEqp);
+                    Assert.True(deletePQqp);
+                    Assert.True(deletPLoot);
+                    testRepo.Dispose();
+                }
+            }
+            finally
+            {
+                connection.Close();
+            }
+        }
+    }
+}

--- a/CookingQuest/CookingQuest.Tests/PlayerTests.cs
+++ b/CookingQuest/CookingQuest.Tests/PlayerTests.cs
@@ -15,9 +15,8 @@ namespace CookingQuest.Tests
     public class PlayerTests
     {
                [Fact]
-        public async Task Add_AdventurerPartyAsync_writes_to_database()
+        public async Task PlayerRepo()
         {
-            // In-memory database only exists while the connection is open
             var connection = new SqliteConnection("DataSource=:memory:");
             connection.Open();
 
@@ -27,16 +26,13 @@ namespace CookingQuest.Tests
                     .UseSqlite(connection)
                     .Options;
 
-                // Create the schema in the database
                 using (var context = new CookingQuestContext(options))
                 {
                     context.Database.EnsureCreated();
                 }
 
-                // Run the test against one instance of the context
                 using (var context = new CookingQuestContext(options))
                 {
-                    //create new Repo
                     context.Player.Add(new Player
                     {
                         Gold = 10,

--- a/CookingQuest/CookingQuest.Tests/PlayerTests.cs
+++ b/CookingQuest/CookingQuest.Tests/PlayerTests.cs
@@ -14,7 +14,285 @@ namespace CookingQuest.Tests
 {
     public class PlayerTests
     {
-               [Fact]
+        [Fact]
+        public async Task PlayerRepoEquipment()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+
+            try
+            {
+                var options = new DbContextOptionsBuilder<CookingQuestContext>()
+                    .UseSqlite(connection)
+                    .Options;
+
+                using (var context = new CookingQuestContext(options))
+                {
+                    context.Database.EnsureCreated();
+                }
+
+                using (var context = new CookingQuestContext(options))
+                {
+                    context.Player.Add(new Player
+                    {
+                        Gold = 10,
+                        Name = "Test",
+                        PlayerId = 1,
+                    });
+                    context.SaveChanges();
+
+                    context.Equipment.Add(new Equipment
+                    {
+                        Difficulty = 8,
+                        EquipmentId = 1,
+                        Modifier = 5,
+                        Name = "TestE",
+                        Price = 45,
+                        Type = "Dungeon",
+                    });
+                    context.Equipment.Add(new Equipment
+                    {
+                        Difficulty = 8,
+                        EquipmentId = 2,
+                        Modifier = 5,
+                        Name = "TestE2",
+                        Price = 45,
+                        Type = "Cooking",
+                    });
+                    context.SaveChanges();
+                    context.PlayerEquipment.Add(new PlayerEquipment
+                    {
+                        EquipmentId = 1,
+                        PlayerId = 1,
+                        PlayerEquipmentId = 1,
+                    });
+                    context.PlayerEquipment.Add(new PlayerEquipment
+                    {
+                        EquipmentId = 2,
+                        PlayerId = 1,
+                        PlayerEquipmentId = 2,
+                    });
+                    context.SaveChanges();
+
+                    var testRepo = new PlayerRepo(context);
+
+                    var playerEqp = await testRepo.GetPlayerEquipment(1);
+                    var name = playerEqp.ElementAt(0).Name;
+
+                    var equip = playerEqp.ElementAt(0);
+                    equip.Name = "Change";
+
+                    var editPEqp = await testRepo.EditPlayerEquipment(equip);
+
+                    var deletePQqp = await testRepo.DeletePlayerEquipment(playerEqp.ElementAt(0).PlayerEquipmentId);
+                    var count = await testRepo.GetPlayerEquipment(1);
+
+                    Assert.True(playerEqp.Count() == 2);
+                    Assert.True(count.Count() == 1);
+                    Assert.Equal("TestE", name);
+                    Assert.Equal("Change", equip.Name);
+                    Assert.Equal("TestE2", (await testRepo.GetPlayerEquipment(1)).ElementAt(0).Name);
+                    testRepo.Dispose();
+                }
+            }
+            finally
+            {
+                connection.Close();
+            }
+        }
+        [Fact]
+        public async Task PlayerRepoLoot()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+
+            try
+            {
+                var options = new DbContextOptionsBuilder<CookingQuestContext>()
+                    .UseSqlite(connection)
+                    .Options;
+
+                using (var context = new CookingQuestContext(options))
+                {
+                    context.Database.EnsureCreated();
+                }
+
+                using (var context = new CookingQuestContext(options))
+                {
+                    context.Player.Add(new Player
+                    {
+                        Gold = 10,
+                        Name = "Test",
+                        PlayerId = 1,
+                    });
+                    context.SaveChanges();
+
+                    context.Loot.Add(new Loot
+                    {
+                        Description = "a",
+                        LootId = 1,
+                        Name = "one",
+                        Price = 44,
+                    });
+                    context.SaveChanges();
+                    context.Loot.Add(new Loot
+                    {
+                        Description = "b",
+                        LootId = 2,
+                        Name = "two",
+                        Price = 100,
+                    });
+                    context.SaveChanges();
+                    context.PlayerLoot.Add(new PlayerLoot
+                    {
+                        LootId = 1,
+                        PlayerId = 1,
+                        PlayerLootId = 1,
+                    });
+                    context.SaveChanges();
+                    context.PlayerLoot.Add(new PlayerLoot
+                    {
+                        LootId = 2,
+                        PlayerId = 1,
+                        PlayerLootId = 2,
+                    });
+                    context.SaveChanges();
+                    var testRepo = new PlayerRepo(context);
+
+                    var loot = await testRepo.GetLoot(1);
+                    var lootS = loot.ElementAt(0);
+                    var name = lootS.Name;
+                    lootS.Name = "Change";
+                    var editPLoot = await testRepo.EditPlayerLoot(lootS);
+                    var deletPLoot = await testRepo.DeletePlayerLoot(loot.ElementAt(1).PlayerLootId);
+                    var count = await testRepo.GetLoot(1);
+
+                    Assert.True(loot.Count() == 2);
+                    Assert.True(count.Count() == 1);
+                    Assert.Equal("one", name);
+                    Assert.Equal("Change", lootS.Name);
+                    Assert.Equal("Change", (await testRepo.GetLoot(1)).ElementAt(0).Name);
+
+
+                    testRepo.Dispose();
+                }
+            }
+            finally
+            {
+                connection.Close();
+            }
+        }
+        [Fact]
+        public async Task PlayerRepoLocations()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+
+            try
+            {
+                var options = new DbContextOptionsBuilder<CookingQuestContext>()
+                    .UseSqlite(connection)
+                    .Options;
+
+                using (var context = new CookingQuestContext(options))
+                {
+                    context.Database.EnsureCreated();
+                }
+
+                using (var context = new CookingQuestContext(options))
+                {
+                    context.Player.Add(new Player
+                    {
+                        Gold = 10,
+                        Name = "Test",
+                        PlayerId = 1,
+                    });
+                    context.SaveChanges();
+                    context.Equipment.Add(new Equipment
+                    {
+                        Difficulty = 8,
+                        EquipmentId = 1,
+                        Modifier = 5,
+                        Name = "TestE",
+                        Price = 45,
+                        Type = "Dungeon",
+                    });
+                    context.SaveChanges();
+                    context.PlayerEquipment.Add(new PlayerEquipment
+                    {
+                        EquipmentId = 1,
+                        PlayerId = 1,
+                        PlayerEquipmentId = 1,
+                    });
+                    context.SaveChanges();
+                    context.Location.Add(new Location
+                    {
+                        Description = "Testl",
+                        Difficulty = 1,
+                        LocationId = 1,
+                        Name = "TestNl",
+                    });
+                    context.SaveChanges();
+
+                    var testRepo = new PlayerRepo(context);
+
+                    var locationUnl = await testRepo.GetUnlockedLocations(1);
+
+                    Assert.Equal("TestNl", locationUnl.ElementAt(0).Name);
+
+
+                    testRepo.Dispose();
+                }
+            }
+            finally
+            {
+                connection.Close();
+            }
+        }
+        [Fact]
+        public async Task PlayerRepoEdit()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+
+            try
+            {
+                var options = new DbContextOptionsBuilder<CookingQuestContext>()
+                    .UseSqlite(connection)
+                    .Options;
+
+                using (var context = new CookingQuestContext(options))
+                {
+                    context.Database.EnsureCreated();
+                }
+
+                using (var context = new CookingQuestContext(options))
+                {
+                    context.Player.Add(new Player
+                    {
+                        Gold = 10,
+                        Name = "Test",
+                        PlayerId = 1,
+                    });
+                    context.SaveChanges();
+
+                    var testRepo = new PlayerRepo(context);
+
+                    var player = await testRepo.GetPlayerById(1);
+
+                    player.Name = "Frank";
+                    var editP = await testRepo.EditPlayer(player);
+
+                    Assert.Equal("Frank", (await testRepo.GetPlayerById(1)).Name);
+                    testRepo.Dispose();
+                }
+            }
+            finally
+            {
+                connection.Close();
+            }
+        }
+        [Fact]
         public async Task PlayerRepo()
         {
             var connection = new SqliteConnection("DataSource=:memory:");
@@ -105,6 +383,7 @@ namespace CookingQuest.Tests
                     Assert.NotNull(player);
                     Assert.Equal("Test", player.Name);
                     Assert.NotNull(playerEmail);
+                    Assert.Equal("Test", player.Name);
                     Assert.NotEmpty(playerEqp);
                     Assert.NotEmpty(locationUnl);
                     Assert.NotEmpty(loot);

--- a/SQL Commands/Database_Insertions_DML.sql
+++ b/SQL Commands/Database_Insertions_DML.sql
@@ -1,9 +1,9 @@
-INSERT INTO cq.Player(Name) 
+INSERT INTO cq.Player(Name, Gold) 
 VALUES
-('Paul'),
-('Sadiki'),
-('Justin'),
-('Batman');
+('Paul',100000),
+('Sadiki',500),
+('Justin',0),
+('Batman',0);
 
 INSERT INTO cq.Account
 (Username,Password,PlayerId)
@@ -13,22 +13,38 @@ VALUES
 ('Justin','password', 3),
 ('Batman','password', 4);
 
+
+
 INSERT INTO cq.Equipment
 (Modifier,Name,Price,Type,Difficulty)
 Values
 (1,'Spoon',10,'Cooking',1),
 (2,'Knife',100,'Cooking',2),
+(3,'Chef Hat', 500, 'Cooking', 3),
+(4,'Stove', 2500, 'Cooking',4),
+(5,'Fridge',10000, 'Cooking', 5),
 (1,'Trowel',10,'Dungeon',1),
-(2,'Spade',100,'Dungeon',2);
+(2,'Spade',100,'Dungeon',2),
+(3,'Hard Hat', 500, 'Dungeon',3),
+(4,'Lawn Mower', 2500, 'Dungeon', 4),
+(5,'Chain Saw', 10000, 'Dungeon',5),
+(1,' Bronze Pass',10 , 'Voucher',1 ),
+(2,' Silver Pass',100 , 'Voucher',2 ),
+(3,' Gold Pass',500 , 'Voucher',3 ),
+(4,' Platinum Pass',2500 , 'Voucher',4 ),
+(5,' Diamond Pass',10000 , 'Voucher',5 ),
+(6,' God Pass',50000 , 'Voucher',6 );
+
+
 
 INSERT INTO cq.Location
 (Name,Difficulty,Description)
 Values
 ('Brinewater Grotto', 1, 'Avoid the Frostbite Spiders. Bitter foods common here.'),
 ('Ravenscar Hollow', 2, 'Home of the mighty Cave Trolls. Known for its cave salt.'),
+('Azeroth', 3, 'It is a Warzone... Better Move Quickly. Chance for an Epic Fruit'), 
 ('Bearzone', 4, 'Endless bear vortex. High number of unami drops.'),
 ('Flavortown', 5, 'Home of the Flavor Gods. All flavors common here.');
-
 INSERT INTO cq.Loot
 (Name,Price,Description)
 Values
@@ -47,13 +63,15 @@ Values
 ('Arugula',50, 'Twice As Healthy As Kale, & Twice As Bitter.'),
 ('Mushrooms',1,'The Fungus Among Us'),
 ('Dried Meat',10,'Portable, If Not Delicious.'),
-('Steak',50, 'Worth Killing a Cow Over.');
+('Steak',50, 'Worth Killing a Cow Over.'),
+('Epic Fruit', 100, 'It is as Large as it is Tasty');
 
 INSERT INTO cq.Recipe
 (Name,Description)
 Values
-('Fruit Combo', 'A Tasty Snack'),
-('Salted Snack', 'Everything is better with Salt');
+('Sweet Combo', 'A Tasty Snack'),
+('Salted Snack', 'Everything is better with Salt'),
+('Spicy Treat', 'It will burn your taste buds off');
 
 INSERT INTO cq.Flavor
 (Name,Description)
@@ -65,66 +83,145 @@ Values
 ('Unami', 'The ultimate in savory. Key for meat dishes.');
 
 INSERT INTO cq.Store
-(Name,Description)
+(Name,Description, Difficulty)
 Values
-('Walmarket','The Market of Commoners. They''ll take anything.'),
-('Blackmarket','The Market of Thieves. Fond of spices.'),
-('Highmarket','The Market of Kings. Nobility craves delicate, sweet things.'),
-('Bookmarket','The Market of Mages. Bitter food improves their magic.'),
-('Faemarket','The Market of Pixies. Sour amuses them.'),
-('Bloodmarket','The Market of Hunters. Only umani can satisfy them.');
+('Walmarket','The Market of Commoners. They''ll take anything.',1),
+('Blackmarket','The Market of Thieves. Fond of spices.',2),
+('Highmarket','The Market of Kings. Nobility craves delicate, sweet things.',3),
+('Bookmarket','The Market of Mages. Bitter food improves their magic.',4),
+('Faemarket','The Market of Pixies. Sour amuses them.',5),
+('Bloodmarket','The Market of Hunters. Only umani can satisfy them.',6);
 
 INSERT INTO cq.Player_Equipment
 (PlayerId,EquipmentId)
 Values
+(1,1),
+(1,2),
 (1,3),
 (1,4),
 (1,5),
 (1,6),
-(2,3),
-(2,5);
+(1,7),
+(1,8),
+(1,9),
+(1,10),
+(1,11),
+(1,12),
+(1,13),
+(1,14),
+(1,15),
+(1,16),
+(2,1),
+(2,2),
+(2,6),
+(2,7),
+(2,11),
+(2,12),
+(3,1),
+(3,6),
+(3,11),
+(3,1),
+(3,6),
+(3,11);
 
 INSERT INTO cq.Player_Location
 (PlayerId,LocationId)
 Values
 (1,1),
 (1,2),
-(2,1);
+(1,3),
+(1,4),
+(1,5),
+(2,1),
+(2,2),
+(3,1),
+(3,2);
 
 INSERT INTO cq.Player_Loot
 (PlayerId,LootId,Quantity)
 Values
 (1,1,10),
 (1,2,5),
-(1,5,10);
+(1,3,1),
+(1,4,100),
+(1,5,2),
+(1,6,3),
+(1,7,8),
+(1,8,20),
+(1,9,21),
+(1,10,5),
+(1,17,10),
+(2,1,3),
+(2,2,5),
+(3,1,1),
+(4,2,1);
 
 INSERT INTO cq.Store_Equipment
 (StoreId,EquipmentId)
 Values
-(1,3),
-(1,5),
-(2,4),
-(2,6);
+(1,1),
+(1,6),
+(1,11),
+(2,2),
+(2,7),
+(2,12),
+(3,3),
+(3,8),
+(3,13),
+(4,4),
+(4,9),
+(4,14),
+(5,5),
+(5,10),
+(5,15);
 
 INSERT INTO cq.Location_Loot
 (LocationId,LootId,DropRate)
 Values
-(1,1,3),
-(1,2,2),
-(1,3,1),
-(2,1,5),
-(2,2,4),
+(1,11,10),
+(1,14,10),
+(1,9,1),
+(2,7,3),
+(2,1,3),
 (2,3,3),
-(2,4,2),
-(2,5,1);
+(2,14,3),
+(3,17,1),
+(3,1,3),
+(3,2,3),
+(3,8,3),
+(3,9,3),
+(4,15,3),
+(4,16,3),
+(4,12,3),
+(4,15,3),
+(5,1,10),
+(5,2,10),
+(5,3,10),
+(5,4,10),
+(5,5,10),
+(5,6,10),
+(5,7,10),
+(5,8,10),
+(5,9,10),
+(5,10,10),
+(5,11,10),
+(5,12,10),
+(5,13,10),
+(5,14,10),
+(5,15,10),
+(5,16,10),
+(5,17,10);
 
 INSERT INTO cq.Recipe_Loot
 (RecipeId, LootId)
 Values
+(1,1),
 (1,2),
-(1,3),
-(2,5),
-(2,4);
+(2,7),
+(2,14),
+(3,15),
+(3,16);
+
 
 INSERT INTO cq.Flavor_Loot
 (FlavorId,LootId)
@@ -143,8 +240,9 @@ Values
 (4,12),
 (5,13),
 (5,14),
-(5,15)
-;
+(5,15),
+(5,16),
+(5,17);
 
 INSERT INTO cq.Store_Flavor
 (StoreId, FlavorId, Bonus)

--- a/SQL Commands/NEW Everything (Create Tables and inserts data).sql
+++ b/SQL Commands/NEW Everything (Create Tables and inserts data).sql
@@ -1,0 +1,672 @@
+DROP TABLE IF EXISTS cq.Store_Flavor
+GO
+DROP TABLE IF EXISTS cq.Store_Equipment
+GO
+DROP TABLE IF EXISTS cq.Store
+GO
+DROP TABLE IF EXISTS cq.Recipe_Loot
+GO
+DROP TABLE IF EXISTS cq.Recipe
+GO
+DROP TABLE IF EXISTS cq.Player_Loot
+GO
+DROP TABLE IF EXISTS cq.Player_Location
+GO
+DROP TABLE IF EXISTS cq.Player_Equipment
+GO
+DROP TABLE IF EXISTS cq.Location_Loot
+GO
+DROP TABLE IF EXISTS cq.Flavor_Loot
+GO
+DROP TABLE IF EXISTS cq.Location
+GO
+DROP TABLE IF EXISTS cq.Flavor
+GO
+DROP TABLE IF EXISTS cq.Equipment
+GO
+DROP TABLE IF EXISTS cq.Account
+GO
+DROP TABLE IF EXISTS cq.Loot
+GO
+DROP TABLE IF EXISTS cq.Player
+GO
+
+
+/****** Object:  Table [cq].[Account]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Account](
+	[AccountId] [int] IDENTITY(1,1) NOT NULL,
+	[Username] [nvarchar](200) NOT NULL,
+	[Password] [nvarchar](200) NOT NULL,
+	[PlayerId] [int] NOT NULL,
+	[IsAdmin] [bit] NOT NULL,
+ CONSTRAINT [PK_AccountId] PRIMARY KEY CLUSTERED 
+(
+	[AccountId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY],
+UNIQUE NONCLUSTERED 
+(
+	[Username] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Equipment]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Equipment](
+	[EquipmentId] [int] IDENTITY(1,1) NOT NULL,
+	[Modifier] [int] NOT NULL,
+	[Name] [nvarchar](200) NOT NULL,
+	[Price] [int] NOT NULL,
+	[Type] [nvarchar](200) NOT NULL,
+	[Difficulty] [int] NOT NULL,
+ CONSTRAINT [PK_EquipmentId] PRIMARY KEY CLUSTERED 
+(
+	[EquipmentId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Flavor]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Flavor](
+	[FlavorId] [int] IDENTITY(1,1) NOT NULL,
+	[Name] [nvarchar](200) NOT NULL,
+	[Description] [nvarchar](200) NOT NULL,
+ CONSTRAINT [PK_FlavorId] PRIMARY KEY CLUSTERED 
+(
+	[FlavorId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Flavor_Loot]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Flavor_Loot](
+	[Flavor_LootId] [int] IDENTITY(1,1) NOT NULL,
+	[FlavorId] [int] NOT NULL,
+	[LootId] [int] NOT NULL,
+ CONSTRAINT [PK_Flavor_Loot] PRIMARY KEY CLUSTERED 
+(
+	[Flavor_LootId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Location]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Location](
+	[LocationId] [int] IDENTITY(1,1) NOT NULL,
+	[Name] [nvarchar](200) NOT NULL,
+	[Difficulty] [int] NOT NULL,
+	[Description] [nvarchar](200) NOT NULL,
+ CONSTRAINT [PK_LocationId] PRIMARY KEY CLUSTERED 
+(
+	[LocationId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Location_Loot]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Location_Loot](
+	[Location_LootId] [int] IDENTITY(1,1) NOT NULL,
+	[LocationId] [int] NOT NULL,
+	[LootId] [int] NOT NULL,
+	[DropRate] [int] NOT NULL,
+ CONSTRAINT [PK_Location_Loot] PRIMARY KEY CLUSTERED 
+(
+	[Location_LootId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Loot]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Loot](
+	[LootId] [int] IDENTITY(1,1) NOT NULL,
+	[Name] [nvarchar](200) NOT NULL,
+	[Price] [int] NOT NULL,
+	[Description] [nvarchar](200) NOT NULL,
+ CONSTRAINT [PK_LootId] PRIMARY KEY CLUSTERED 
+(
+	[LootId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Player]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Player](
+	[PlayerId] [int] IDENTITY(1,1) NOT NULL,
+	[Name] [nvarchar](200) NOT NULL,
+	[Gold] [int] NOT NULL,
+ CONSTRAINT [PK_PlayerId] PRIMARY KEY CLUSTERED 
+(
+	[PlayerId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Player_Equipment]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Player_Equipment](
+	[Player_EquipmentId] [int] IDENTITY(1,1) NOT NULL,
+	[PlayerId] [int] NOT NULL,
+	[EquipmentId] [int] NOT NULL,
+ CONSTRAINT [PK_Player_EquipmentId] PRIMARY KEY CLUSTERED 
+(
+	[Player_EquipmentId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Player_Location]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Player_Location](
+	[Player_Location] [int] IDENTITY(1,1) NOT NULL,
+	[PlayerId] [int] NOT NULL,
+	[LocationId] [int] NOT NULL,
+ CONSTRAINT [PK_Player_Location] PRIMARY KEY CLUSTERED 
+(
+	[Player_Location] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Player_Loot]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Player_Loot](
+	[Player_LootId] [int] IDENTITY(1,1) NOT NULL,
+	[PlayerId] [int] NOT NULL,
+	[LootId] [int] NOT NULL,
+	[Quantity] [int] NOT NULL,
+ CONSTRAINT [PK_Player_Loot] PRIMARY KEY CLUSTERED 
+(
+	[Player_LootId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Recipe]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Recipe](
+	[RecipeId] [int] IDENTITY(1,1) NOT NULL,
+	[Name] [nvarchar](200) NOT NULL,
+	[Description] [nvarchar](200) NOT NULL,
+ CONSTRAINT [PK_RecipeId] PRIMARY KEY CLUSTERED 
+(
+	[RecipeId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Recipe_Loot]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Recipe_Loot](
+	[Recipe_LootId] [int] IDENTITY(1,1) NOT NULL,
+	[RecipeId] [int] NOT NULL,
+	[LootId] [int] NOT NULL,
+ CONSTRAINT [PK_Recipe_Loot] PRIMARY KEY CLUSTERED 
+(
+	[Recipe_LootId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Store]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Store](
+	[StoreId] [int] IDENTITY(1,1) NOT NULL,
+	[Name] [nvarchar](200) NOT NULL,
+	[Description] [nvarchar](200) NOT NULL,
+	[Difficulty] [int] NOT NULL,
+ CONSTRAINT [PK_StoreId] PRIMARY KEY CLUSTERED 
+(
+	[StoreId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Store_Equipment]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Store_Equipment](
+	[Store_EquipmentId] [int] IDENTITY(1,1) NOT NULL,
+	[StoreId] [int] NOT NULL,
+	[EquipmentId] [int] NOT NULL,
+ CONSTRAINT [PK_Store_Equipment] PRIMARY KEY CLUSTERED 
+(
+	[Store_EquipmentId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+/****** Object:  Table [cq].[Store_Flavor]    Script Date: 5/26/2019 6:59:27 PM ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [cq].[Store_Flavor](
+	[Store_FlavorId] [int] IDENTITY(1,1) NOT NULL,
+	[StoreId] [int] NOT NULL,
+	[FlavorId] [int] NOT NULL,
+	[Bonus] [int] NOT NULL,
+ CONSTRAINT [PK_Store_Flavor] PRIMARY KEY CLUSTERED 
+(
+	[Store_FlavorId] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+ALTER TABLE [cq].[Account] ADD  DEFAULT ((0)) FOR [IsAdmin]
+GO
+ALTER TABLE [cq].[Equipment] ADD  DEFAULT ((1)) FOR [Modifier]
+GO
+ALTER TABLE [cq].[Equipment] ADD  DEFAULT ('Dungeon') FOR [Type]
+GO
+ALTER TABLE [cq].[Loot] ADD  DEFAULT ((0)) FOR [Price]
+GO
+ALTER TABLE [cq].[Player] ADD  DEFAULT ((0)) FOR [Gold]
+GO
+ALTER TABLE [cq].[Store] ADD  DEFAULT ((1)) FOR [Difficulty]
+GO
+ALTER TABLE [cq].[Account]  WITH CHECK ADD  CONSTRAINT [FK_Player] FOREIGN KEY([PlayerId])
+REFERENCES [cq].[Player] ([PlayerId])
+GO
+ALTER TABLE [cq].[Account] CHECK CONSTRAINT [FK_Player]
+GO
+ALTER TABLE [cq].[Flavor_Loot]  WITH CHECK ADD  CONSTRAINT [FK_Flavor_Loot] FOREIGN KEY([FlavorId])
+REFERENCES [cq].[Flavor] ([FlavorId])
+GO
+ALTER TABLE [cq].[Flavor_Loot] CHECK CONSTRAINT [FK_Flavor_Loot]
+GO
+ALTER TABLE [cq].[Flavor_Loot]  WITH CHECK ADD  CONSTRAINT [FK_Loot_Flavor] FOREIGN KEY([LootId])
+REFERENCES [cq].[Loot] ([LootId])
+GO
+ALTER TABLE [cq].[Flavor_Loot] CHECK CONSTRAINT [FK_Loot_Flavor]
+GO
+ALTER TABLE [cq].[Location_Loot]  WITH CHECK ADD  CONSTRAINT [FK_Location_Loot] FOREIGN KEY([LocationId])
+REFERENCES [cq].[Location] ([LocationId])
+GO
+ALTER TABLE [cq].[Location_Loot] CHECK CONSTRAINT [FK_Location_Loot]
+GO
+ALTER TABLE [cq].[Location_Loot]  WITH CHECK ADD  CONSTRAINT [FK_Loot_Location] FOREIGN KEY([LootId])
+REFERENCES [cq].[Loot] ([LootId])
+GO
+ALTER TABLE [cq].[Location_Loot] CHECK CONSTRAINT [FK_Loot_Location]
+GO
+ALTER TABLE [cq].[Player_Equipment]  WITH CHECK ADD  CONSTRAINT [FK_EquipmentId_PlayerId] FOREIGN KEY([EquipmentId])
+REFERENCES [cq].[Equipment] ([EquipmentId])
+GO
+ALTER TABLE [cq].[Player_Equipment] CHECK CONSTRAINT [FK_EquipmentId_PlayerId]
+GO
+ALTER TABLE [cq].[Player_Equipment]  WITH CHECK ADD  CONSTRAINT [FK_PlayerId_EquipmentId] FOREIGN KEY([PlayerId])
+REFERENCES [cq].[Player] ([PlayerId])
+GO
+ALTER TABLE [cq].[Player_Equipment] CHECK CONSTRAINT [FK_PlayerId_EquipmentId]
+GO
+ALTER TABLE [cq].[Player_Location]  WITH CHECK ADD  CONSTRAINT [FK_Location_Player] FOREIGN KEY([LocationId])
+REFERENCES [cq].[Location] ([LocationId])
+GO
+ALTER TABLE [cq].[Player_Location] CHECK CONSTRAINT [FK_Location_Player]
+GO
+ALTER TABLE [cq].[Player_Location]  WITH CHECK ADD  CONSTRAINT [FK_Player_Location] FOREIGN KEY([PlayerId])
+REFERENCES [cq].[Player] ([PlayerId])
+GO
+ALTER TABLE [cq].[Player_Location] CHECK CONSTRAINT [FK_Player_Location]
+GO
+ALTER TABLE [cq].[Player_Loot]  WITH CHECK ADD  CONSTRAINT [FK_Loot_Player] FOREIGN KEY([LootId])
+REFERENCES [cq].[Loot] ([LootId])
+GO
+ALTER TABLE [cq].[Player_Loot] CHECK CONSTRAINT [FK_Loot_Player]
+GO
+ALTER TABLE [cq].[Player_Loot]  WITH CHECK ADD  CONSTRAINT [FK_Player_Loot] FOREIGN KEY([PlayerId])
+REFERENCES [cq].[Player] ([PlayerId])
+GO
+ALTER TABLE [cq].[Player_Loot] CHECK CONSTRAINT [FK_Player_Loot]
+GO
+ALTER TABLE [cq].[Recipe_Loot]  WITH CHECK ADD  CONSTRAINT [FK_Loot_Recipe] FOREIGN KEY([LootId])
+REFERENCES [cq].[Loot] ([LootId])
+GO
+ALTER TABLE [cq].[Recipe_Loot] CHECK CONSTRAINT [FK_Loot_Recipe]
+GO
+ALTER TABLE [cq].[Recipe_Loot]  WITH CHECK ADD  CONSTRAINT [FK_Recipe_Loot] FOREIGN KEY([RecipeId])
+REFERENCES [cq].[Recipe] ([RecipeId])
+GO
+ALTER TABLE [cq].[Recipe_Loot] CHECK CONSTRAINT [FK_Recipe_Loot]
+GO
+ALTER TABLE [cq].[Store_Equipment]  WITH CHECK ADD  CONSTRAINT [FK_EquipmentId_Store] FOREIGN KEY([EquipmentId])
+REFERENCES [cq].[Equipment] ([EquipmentId])
+GO
+ALTER TABLE [cq].[Store_Equipment] CHECK CONSTRAINT [FK_EquipmentId_Store]
+GO
+ALTER TABLE [cq].[Store_Equipment]  WITH CHECK ADD  CONSTRAINT [FK_Store_Equipment] FOREIGN KEY([StoreId])
+REFERENCES [cq].[Store] ([StoreId])
+GO
+ALTER TABLE [cq].[Store_Equipment] CHECK CONSTRAINT [FK_Store_Equipment]
+GO
+ALTER TABLE [cq].[Store_Flavor]  WITH CHECK ADD  CONSTRAINT [FK_Flavor_Store] FOREIGN KEY([FlavorId])
+REFERENCES [cq].[Flavor] ([FlavorId])
+GO
+ALTER TABLE [cq].[Store_Flavor] CHECK CONSTRAINT [FK_Flavor_Store]
+GO
+ALTER TABLE [cq].[Store_Flavor]  WITH CHECK ADD  CONSTRAINT [FK_Store_Flavor] FOREIGN KEY([StoreId])
+REFERENCES [cq].[Store] ([StoreId])
+GO
+ALTER TABLE [cq].[Store_Flavor] CHECK CONSTRAINT [FK_Store_Flavor]
+GO
+ALTER TABLE [cq].[Equipment]  WITH CHECK ADD CHECK  (([Difficulty]>=(1) AND [Difficulty]<=(9)))
+GO
+ALTER TABLE [cq].[Location]  WITH CHECK ADD CHECK  (([Difficulty]>=(1) AND [Difficulty]<=(9)))
+GO
+ALTER TABLE [cq].[Store]  WITH CHECK ADD CHECK  (([Difficulty]>=(1) AND [Difficulty]<=(9)))
+GO
+
+INSERT INTO cq.Player(Name, Gold) 
+VALUES
+('Paul',100000),
+('Sadiki',500),
+('Justin',0),
+('Batman',0);
+
+INSERT INTO cq.Account
+(Username,Password,PlayerId)
+VALUES
+('pauls_awesome@hotmail.com','password', 1),
+('paul_grimes8@hotmail.com','password', 2),
+('Justin','password', 3),
+('Batman','password', 4);
+
+
+
+INSERT INTO cq.Equipment
+(Modifier,Name,Price,Type,Difficulty)
+Values
+(1,'Spoon',10,'Cooking',1),
+(2,'Knife',100,'Cooking',2),
+(3,'Chef Hat', 500, 'Cooking', 3),
+(4,'Stove', 2500, 'Cooking',4),
+(5,'Fridge',10000, 'Cooking', 5),
+(1,'Trowel',10,'Dungeon',1),
+(2,'Spade',100,'Dungeon',2),
+(3,'Hard Hat', 500, 'Dungeon',3),
+(4,'Lawn Mower', 2500, 'Dungeon', 4),
+(5,'Chain Saw', 10000, 'Dungeon',5),
+(1,' Bronze Pass',10 , 'Voucher',1 ),
+(2,' Silver Pass',100 , 'Voucher',2 ),
+(3,' Gold Pass',500 , 'Voucher',3 ),
+(4,' Platinum Pass',2500 , 'Voucher',4 ),
+(5,' Diamond Pass',10000 , 'Voucher',5 ),
+(6,' God Pass',50000 , 'Voucher',6 );
+
+
+
+INSERT INTO cq.Location
+(Name,Difficulty,Description)
+Values
+('Brinewater Grotto', 1, 'Avoid the Frostbite Spiders. Bitter foods common here.'),
+('Ravenscar Hollow', 2, 'Home of the mighty Cave Trolls. Known for its cave salt.'),
+('Azeroth', 3, 'It is a Warzone... Better Move Quickly. Chance for an Epic Fruit'), 
+('Bearzone', 4, 'Endless bear vortex. High number of unami drops.'),
+('Flavortown', 5, 'Home of the Flavor Gods. All flavors common here.');
+INSERT INTO cq.Loot
+(Name,Price,Description)
+Values
+('Apple',1,'A Simple Apple'),
+('Blueberries',10,'Zesty and Fun'),
+('Sugarcane', 50, 'Chewy & Sweet'),
+('Bell Pepper', 1, 'Mildly spicy'),
+('Japaleño Pepper', 10, 'Pretty spicy'),
+('Habanero Pepper', 50, 'Flaming breath levels of spicy'),
+('Rock salt',50,'An honest day''s wages.'),
+('Orange',1,'Citrus Blast'),
+('Cranberries',10,'More Sour Than Sweet'),
+('Pickle',50, 'A Cucumber, Irrevocably Tainted'),
+('Coffee Beans',1,'Who Needs Sleep?'),
+('Kale',10,'Gotta Get Healthy.'),
+('Arugula',50, 'Twice As Healthy As Kale, & Twice As Bitter.'),
+('Mushrooms',1,'The Fungus Among Us'),
+('Dried Meat',10,'Portable, If Not Delicious.'),
+('Steak',50, 'Worth Killing a Cow Over.'),
+('Epic Fruit', 100, 'It is as Large as it is Tasty');
+
+INSERT INTO cq.Recipe
+(Name,Description)
+Values
+('Sweet Combo', 'A Tasty Snack'),
+('Salted Snack', 'Everything is better with Salt'),
+('Spicy Treat', 'It will burn your taste buds off');
+
+INSERT INTO cq.Flavor
+(Name,Description)
+Values
+('Sweet','Sweet to the taste. Good for desserts and candies.'),
+('Spicy','The hotter the better. Best found in peppers.'),
+('Sour','Mouth-puckering goodness. Mostly fruits, but also vinegar.'),
+('Bitter', 'When your tongue needs a challenge. Coffee, olives and the like'),
+('Unami', 'The ultimate in savory. Key for meat dishes.');
+
+INSERT INTO cq.Store
+(Name,Description, Difficulty)
+Values
+('Walmarket','The Market of Commoners. They''ll take anything.',1),
+('Blackmarket','The Market of Thieves. Fond of spices.',2),
+('Highmarket','The Market of Kings. Nobility craves delicate, sweet things.',3),
+('Bookmarket','The Market of Mages. Bitter food improves their magic.',4),
+('Faemarket','The Market of Pixies. Sour amuses them.',5),
+('Bloodmarket','The Market of Hunters. Only umani can satisfy them.',6);
+
+INSERT INTO cq.Player_Equipment
+(PlayerId,EquipmentId)
+Values
+(1,1),
+(1,2),
+(1,3),
+(1,4),
+(1,5),
+(1,6),
+(1,7),
+(1,8),
+(1,9),
+(1,10),
+(1,11),
+(1,12),
+(1,13),
+(1,14),
+(1,15),
+(1,16),
+(2,1),
+(2,2),
+(2,6),
+(2,7),
+(2,11),
+(2,12),
+(3,1),
+(3,6),
+(3,11),
+(3,1),
+(3,6),
+(3,11);
+
+INSERT INTO cq.Player_Location
+(PlayerId,LocationId)
+Values
+(1,1),
+(1,2),
+(1,3),
+(1,4),
+(1,5),
+(2,1),
+(2,2),
+(3,1),
+(3,2);
+
+INSERT INTO cq.Player_Loot
+(PlayerId,LootId,Quantity)
+Values
+(1,1,10),
+(1,2,5),
+(1,3,1),
+(1,4,100),
+(1,5,2),
+(1,6,3),
+(1,7,8),
+(1,8,20),
+(1,9,21),
+(1,10,5),
+(1,17,10),
+(2,1,3),
+(2,2,5),
+(3,1,1),
+(4,2,1);
+
+INSERT INTO cq.Store_Equipment
+(StoreId,EquipmentId)
+Values
+(1,1),
+(1,6),
+(1,11),
+(2,2),
+(2,7),
+(2,12),
+(3,3),
+(3,8),
+(3,13),
+(4,4),
+(4,9),
+(4,14),
+(5,5),
+(5,10),
+(5,15);
+
+INSERT INTO cq.Location_Loot
+(LocationId,LootId,DropRate)
+Values
+(1,11,10),
+(1,14,10),
+(1,9,1),
+(2,7,3),
+(2,1,3),
+(2,3,3),
+(2,14,3),
+(3,17,1),
+(3,1,3),
+(3,2,3),
+(3,8,3),
+(3,9,3),
+(4,15,3),
+(4,16,3),
+(4,12,3),
+(4,15,3),
+(5,1,10),
+(5,2,10),
+(5,3,10),
+(5,4,10),
+(5,5,10),
+(5,6,10),
+(5,7,10),
+(5,8,10),
+(5,9,10),
+(5,10,10),
+(5,11,10),
+(5,12,10),
+(5,13,10),
+(5,14,10),
+(5,15,10),
+(5,16,10),
+(5,17,10);
+
+INSERT INTO cq.Recipe_Loot
+(RecipeId, LootId)
+Values
+(1,1),
+(1,2),
+(2,7),
+(2,14),
+(3,15),
+(3,16);
+
+
+INSERT INTO cq.Flavor_Loot
+(FlavorId,LootId)
+Values
+(1,1),
+(1,2),
+(1,3),
+(2,4),
+(2,5),
+(2,6),
+(3,7),
+(3,8),
+(3,9),
+(4,10),
+(4,11),
+(4,12),
+(5,13),
+(5,14),
+(5,15),
+(5,16),
+(5,17);
+
+INSERT INTO cq.Store_Flavor
+(StoreId, FlavorId, Bonus)
+Values
+(1,1,2),
+(1,2,2),
+(1,3,2),
+(1,4,2),
+(1,5,2),
+(2,1,2),
+(2,2,4),
+(2,3,2),
+(2,4,2),
+(2,5,3),
+(3,1,4),
+(3,2,1),
+(3,3,2),
+(3,4,2),
+(3,5,2),
+(4,1,2),
+(4,2,2),
+(4,3,2),
+(4,4,4),
+(4,5,2),
+(5,1,2),
+(5,2,2),
+(5,3,4),
+(5,4,2),
+(5,5,2),
+(6,1,2),
+(6,2,2),
+(6,3,2),
+(6,4,2),
+(6,5,4);


### PR DESCRIPTION
Admin can create and edit both loot and equipment -- also displayed all in tables

Player profile page now can edit and delete loot and equipment from player (if admin)
    This can impact both loot and the player_loot table which has the quantity

Put scrollbars on all my tables

I also updated SQL to drop all tables, add all tables back and insert data (you will probably have to put your email into the insertion though)